### PR TITLE
[Fix] Fix CalledFromWrongThreadException In LoginActivity And Package…

### DIFF
--- a/app/src/main/java/com/thangnvhe/bookingroom/ui/MainActivity.java
+++ b/app/src/main/java/com/thangnvhe/bookingroom/ui/MainActivity.java
@@ -4,6 +4,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
+import androidx.appcompat.widget.Toolbar;
 
 import androidx.appcompat.app.AppCompatActivity;
 
@@ -20,6 +21,9 @@ public class MainActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
+        Toolbar toolbar = findViewById(R.id.main_toolbar);
+        setSupportActionBar(toolbar);
+
         viewModel = new AuthViewModel(this);
 
         // Kiểm tra đăng nhập
@@ -30,7 +34,7 @@ public class MainActivity extends AppCompatActivity {
         }
 
         // Khởi tạo màn hình chính (ví dụ: điều hướng đến PackageListActivity)
-        startActivity(new Intent(this, PackageListActivity.class));
+//        startActivity(new Intent(this, PackageListActivity.class));
     }
 
     @Override

--- a/app/src/main/java/com/thangnvhe/bookingroom/ui/auth/LoginActivity.java
+++ b/app/src/main/java/com/thangnvhe/bookingroom/ui/auth/LoginActivity.java
@@ -51,14 +51,18 @@ public class LoginActivity extends AppCompatActivity {
 
                     @Override
                     public void onSuccess(int userId) {
-                        Toast.makeText(LoginActivity.this, "Đăng nhập thành công", Toast.LENGTH_SHORT).show();
-                        startActivity(new Intent(LoginActivity.this, PackageListActivity.class));
-                        finish();
+                        runOnUiThread(() -> {
+                            Toast.makeText(LoginActivity.this, "Đăng nhập thành công", Toast.LENGTH_SHORT).show();
+                            startActivity(new Intent(LoginActivity.this, PackageListActivity.class));
+                            finish();
+                        });
                     }
 
                     @Override
                     public void onError(String message) {
-                        Toast.makeText(LoginActivity.this, message, Toast.LENGTH_SHORT).show();
+                        runOnUiThread(() -> {
+                            Toast.makeText(LoginActivity.this, message, Toast.LENGTH_SHORT).show();
+                        });
                     }
                 });
             }

--- a/app/src/main/java/com/thangnvhe/bookingroom/ui/packages/PackageListActivity.java
+++ b/app/src/main/java/com/thangnvhe/bookingroom/ui/packages/PackageListActivity.java
@@ -2,6 +2,8 @@ package com.thangnvhe.bookingroom.ui.packages;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.view.View;
+import android.widget.TextView;
 
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.recyclerview.widget.LinearLayoutManager;
@@ -11,6 +13,7 @@ import com.thangnvhe.bookingroom.R;
 import com.thangnvhe.bookingroom.data.db.entities.Package;
 import com.thangnvhe.bookingroom.data.repositories.PackageRepository;
 import com.thangnvhe.bookingroom.ui.adapter.PackageAdapter;
+import com.thangnvhe.bookingroom.ui.auth.LoginActivity;
 
 import java.util.List;
 
@@ -31,12 +34,24 @@ public class PackageListActivity extends AppCompatActivity {
         viewModel.getPackages(new PackageRepository.OnPackageResultListener() {
             @Override
             public void onSuccess(List<Package> packages) {
-                adapter = new PackageAdapter(packages, pkg -> {
-                    Intent intent = new Intent(PackageListActivity.this, PackageDetailActivity.class);
-                    intent.putExtra("PACKAGE_ID", pkg.id);
-                    startActivity(intent);
+                runOnUiThread(() -> {
+                    TextView emptyTextView = findViewById(R.id.emptyTextView);
+
+                    if (packages == null || packages.isEmpty()) {
+                        emptyTextView.setVisibility(View.VISIBLE);
+                        recyclerView.setVisibility(View.GONE);
+                    } else {
+                        emptyTextView.setVisibility(View.GONE);
+                        recyclerView.setVisibility(View.VISIBLE);
+
+                        adapter = new PackageAdapter(packages, pkg -> {
+                            Intent intent = new Intent(PackageListActivity.this, PackageDetailActivity.class);
+                            intent.putExtra("PACKAGE_ID", pkg.id);
+                            startActivity(intent);
+                        });
+                        recyclerView.setAdapter(adapter);
+                    }
                 });
-                recyclerView.setAdapter(adapter);
             }
         });
     }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,9 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
     android:gravity="center">
+
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/main_toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="?attr/colorPrimary"
+        app:title="Booking Room"
+        app:titleTextColor="@android:color/white"/>
 
     <TextView
         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/activity_package_list.xml
+++ b/app/src/main/res/layout/activity_package_list.xml
@@ -4,10 +4,20 @@
     android:layout_height="match_parent"
     android:orientation="vertical"
     android:padding="16dp">
-
+    <TextView
+        android:id="@+id/emptyTextView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Danh sách trống"
+        android:textSize="16sp"
+        android:gravity="center"
+        android:visibility="gone"
+        android:padding="16dp"
+        />
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recycler_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         />
+
 </LinearLayout>

--- a/app/src/main/res/menu/main_menu.xml
+++ b/app/src/main/res/menu/main_menu.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<menu xmlns:android="http://schemas.android.com/apk/res/android">
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
         android:id="@+id/action_logout"
-        android:title="Đăng xuất" />
+        android:title="Đăng xuất"
+        android:icon="@drawable/ic_launcher_foreground"
+        app:showAsAction="ifRoom|withText" />
 </menu>


### PR DESCRIPTION
Lỗi này xảy ra khi bạn cố gắng cập nhật giao diện người dùng (UI) từ một luồng (thread) không phải là luồng chính (main thread) hay còn gọi là UI thread.

Trong Android, tất cả các thao tác liên quan đến UI (ví dụ: cập nhật TextView, thay đổi Adapter cho RecyclerView, hiển thị Toast, v.v.) phải được thực hiện trên Main Thread. Nếu bạn cố gắng thay đổi UI từ một luồng nền (background thread), hệ thống sẽ ném ra lỗi này để ngăn chặn các vấn đề về đồng bộ hóa và tính ổn định của UI.
 
Cách Fix: dùng runOnUiThread()
      
   Ví dụ:  runOnUiThread(() -> {
                    Toast.makeText(LoginActivity.this, message, Toast.LENGTH_SHORT).show();
                });